### PR TITLE
Add back the /data/birna01 mountpoint

### DIFF
--- a/mountpoints.yml
+++ b/mountpoints.yml
@@ -313,6 +313,18 @@ jwd:
       - hard
       - rw
       - nosuid
+  birna01:
+    name: birna01
+    path: /data/birna01
+    export: denbi.svm.bwsfs.uni-freiburg.de:/&
+    docker_perm: ro
+    nfs_options:
+      - hard
+      - rw
+      - nosuid
+      - nodev
+      - nconnect=2
+
 sync:
   gxtst:
     name: gxtst


### PR DESCRIPTION
The RNA server requires that `/data/birna01` be mounted from `denbi.svm.bwsfs.uni-freiburg.de:/birna01` on the vgcn-workers. This mount point definition appears to have been inadvertedly dropped when transitioning the autofs config to this repo and this PR adds it back.

(I decided to just add `birna01` as yet another JWD rather than adding a third loop to `templates/vgcn-mounts.yml.j2` that would ultimately expand to just one line.)