### PR TITLE
Fix celery cluster key in group-vars-all.yml.j2

### DIFF
--- a/templates/group-vars-all.yml.j2
+++ b/templates/group-vars-all.yml.j2
@@ -17,6 +17,6 @@ autofs_conf_files:
     {% for mount in tools.values() %}
     - {{ mount.name }}				-{{ mount.nfs_options | join(',') }}				{{ mount.export }}
     {% endfor %}
-  celerycluster:
+  usrlocal_celerycluster:
     - {{ tmp.tmp.path }}      -{{ tmp.tmp.nfs_options | join(',') }}      {{ tmp.tmp.export }}
     - /opt/galaxy    	    		-{{ sync.gxkey.nfs_options | join(',') }}			{{ sync.gxkey.export }}


### PR DESCRIPTION
Replace `celerycluster` with `usrlocal_celerycluster`.

The celery playbook is still failing due to this, so this can be considered as a follow-up to [usegalaxy-eu/infrastructure-playbook#824](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/824).