### PR TITLE
New mountpoint /data/dnb-ds03

### DIFF
--- a/mountpoints.yml
+++ b/mountpoints.yml
@@ -157,6 +157,17 @@ dnb:
       - nosuid
       - nconnect=2
       - nodev
+  dnb_ds03:
+    name: dnb-ds03
+    path: /data/dnb-ds03
+    export: denbi.svm.bwsfs.uni-freiburg.de:/dnb03-legacy
+    docker_perm: ro
+    nfs_options:
+      - hard
+      - rw
+      - nosuid
+      - nconnect=2
+      - nodev
   dnb01:
     name: dnb01
     path: /data/dnb01


### PR DESCRIPTION
Create a new mountpoint for the migrated copy of the `dnb03` object store, exactly analogous to what we previously did with `dnb01` and `dnb02`. This new mount point will replace the current location for `dnb03` eventually, at which point we'll have migrated all Galaxy object stores away from the Isilon system.