### PR TITLE
Fix typo in vgcn-mounts.yml

### DIFF
--- a/vgcn-mounts.yml
+++ b/vgcn-mounts.yml
@@ -13,6 +13,6 @@
     - name: Description
       # Comment
       ansible.builtin.blockinfile:
-        path: ../userdata.yml.j2
+        path: ../userdata.yaml.j2
         block: "{{ lookup('file', 'dest/vgcn-mounts.yml') }}"
         insertafter: EOF


### PR DESCRIPTION
Replace `../userdata.yml.j2` with `../userdata.yaml.j2`.