### PR TITLE
add new shares from the zfs06

### DIFF
--- a/mountpoints.yml
+++ b/mountpoints.yml
@@ -432,7 +432,6 @@ cache:
       - hard
       - rw
       - nosuid
-      - nconnect=2
 
 misc:
   misc06:
@@ -444,4 +443,3 @@ misc:
       - hard
       - rw
       - nosuid
-      - nconnect=2

--- a/mountpoints.yml
+++ b/mountpoints.yml
@@ -335,6 +335,15 @@ jwd:
       - hard
       - rw
       - nosuid
+  jwd06:
+    name: jwd06
+    path: /data/jwd06
+    export: zfs06.bi.privat:/export/&
+    docker_perm: rw
+    nfs_options:
+      - hard
+      - rw
+      - nosuid
   birna01:
     name: birna01
     path: /data/birna01
@@ -407,6 +416,30 @@ tools:
     path: /usr/local/tools
     export: denbi.svm.bwsfs.uni-freiburg.de:/dnb01/tools
     docker_perm: ro
+    nfs_options:
+      - hard
+      - rw
+      - nosuid
+      - nconnect=2
+
+cache:
+  cache06:
+    name: cache06
+    path: /data/cache06
+    export: zfs06.bi.privat:/export/&
+    docker_perm: rw
+    nfs_options:
+      - hard
+      - rw
+      - nosuid
+      - nconnect=2
+
+misc:
+  misc06:
+    name: misc06
+    path: /data/misc06
+    export: zfs06.bi.privat:/export/&
+    docker_perm: rw
     nfs_options:
       - hard
       - rw

--- a/templates/group-vars-all.yml.j2
+++ b/templates/group-vars-all.yml.j2
@@ -20,3 +20,11 @@ autofs_conf_files:
   usrlocal_celerycluster:
     - {{ tmp.tmp.path }}      -{{ tmp.tmp.nfs_options | join(',') }}      {{ tmp.tmp.export }}
     - /opt/galaxy    	    		-{{ sync.gxkey.nfs_options | join(',') }}			{{ sync.gxkey.export }}
+  cache:
+    {% for mount in cache.values() %}
+    - {{ mount.name }}				-{{ mount.nfs_options | join(',') }}				{{ mount.export }}
+    {% endfor %}
+  misc:
+    {% for mount in misc.values() %}
+    - {{ mount.name }}				-{{ mount.nfs_options | join(',') }}				{{ mount.export }}
+    {% endfor %}


### PR DESCRIPTION
Adds JWD, cache and misc. All of them will be mounted under `/data`.

@sj213 These days, the default mount for NFS is probably version 4. So, I'm not explicitly defining that in the `nfs_options`. Also, are you exporting only the nfsv4?