### PR TITLE
Remove the zfs2f mount point, as the corresponding NFS server will be retired

### DIFF
--- a/mountpoints.yml
+++ b/mountpoints.yml
@@ -323,16 +323,6 @@ jwd:
       - rw
       - nosuid
       - vers=3
-  jwd02f:
-    name: jwd02f
-    path: /data/jwd02f
-    export: zfs2f.galaxyproject.eu:/export/&
-    docker_perm: rw
-    nfs_options:
-      - hard
-      - rw
-      - nosuid
-      - vers=3
   jwd03f:
     name: jwd03f
     path: /data/jwd03f


### PR DESCRIPTION
ToDo: Manually remove this share from all the workers' Autofs conf (use PSSH or something alike).