### PR TITLE
Revert "Add zfs08 shares to the mountpoints"

### DIFF
--- a/mountpoints.yml
+++ b/mountpoints.yml
@@ -384,15 +384,6 @@ jwd:
       - hard
       - rw
       - nosuid
-  jwd08:
-    name: jwd08
-    path: /data/jwd08
-    export: zfs08.bi.privat:/export/&
-    docker_perm: rw
-    nfs_options:
-      - hard
-      - rw
-      - nosuid
   birna01:
     name: birna01
     path: /data/birna01
@@ -497,15 +488,6 @@ cache:
       - hard
       - rw
       - nosuid
-  cache08:
-    name: cache08
-    path: /data/cache08
-    export: zfs08.bi.privat:/export/&
-    docker_perm: rw
-    nfs_options:
-      - hard
-      - rw
-      - nosuid
 
 misc:
   misc06:
@@ -521,15 +503,6 @@ misc:
     name: misc07
     path: /data/misc07
     export: zfs07.bi.privat:/export/&
-    docker_perm: rw
-    nfs_options:
-      - hard
-      - rw
-      - nosuid
-  misc08:
-    name: misc08
-    path: /data/misc08
-    export: zfs08.bi.privat:/export/&
     docker_perm: rw
     nfs_options:
       - hard


### PR DESCRIPTION
Reverts usegalaxy-eu/mounts#21, because the following error was observed (likely due to `root_squash`).

```
docker: Error response from daemon: error while creating mount source path '/data/cache08/object_store_cache': mkdir /data/cache08: permission denied.
```

