### PR TITLE
Add cvmfs08 share to the mountpoints

### DIFF
--- a/mountpoints.yml
+++ b/mountpoints.yml
@@ -487,6 +487,17 @@ cache:
       - rw
       - nosuid
 
+cvmfs:
+  cvmfs08:
+    name: cvmfs08
+    path: /data/cvmfs08
+    export: zfs08.bi.privat:/export/&
+    docker_perm: ro
+    nfs_options:
+      - hard
+      - rw
+      - nosuid
+
 misc:
   misc06:
     name: misc06


### PR DESCRIPTION
This new share `/data/cvmfs08` will be used exclusively to store the CVMFS alien cache on NFS.

⚠️ Do not merge until [the share has been setup](https://github.com/usegalaxy-eu/issues/issues/157#issuecomment-3871546860).
